### PR TITLE
An atom based identity.

### DIFF
--- a/examples/table.js
+++ b/examples/table.js
@@ -1,6 +1,6 @@
 import { create } from '../index';
 import { query } from '../src/query';
-import { link, ownerOf, pathOf, valueOf, metaOf, atomOf, location } from '../src/meta';
+import { link, ownerOf, pathOf, valueOf, atomOf, location } from '../src/meta';
 
 export default function Table(T) {
   class Table {
@@ -59,7 +59,7 @@ export default function Table(T) {
     *[Symbol.iterator]() {
       let i = -1;
       let { table, index } = this;
-      for (let _ of valueOf(table)[index]) {
+      for (let _ of valueOf(table)[index]) { //eslint-disable-line
         i++;
         yield link(create(T), location(T, pathOf(table).concat([index, i])), atomOf(table), ownerOf(table));
       }
@@ -75,7 +75,7 @@ export default function Table(T) {
     *[Symbol.iterator]() {
       let i = -1;
       let { table, index } = this;
-      for (let _ of valueOf(table)) {
+      for (let _ of valueOf(table)) { //eslint-disable-line
         i++;
         yield link(create(T), location(T, pathOf(table).concat([i, index])), atomOf(table), ownerOf(table));
       }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import create from './src/create';
+import Identity from './src/identity';
 
-export { create };
+export { create, Identity };
 export { valueOf, metaOf, atomOf } from './src/meta';

--- a/src/identity.js
+++ b/src/identity.js
@@ -1,0 +1,75 @@
+import MicrostateType from './microstate-type';
+import { At, view, compose, Path } from './lens';
+import { typeOf, valueOf, pathOf, link2, AtomOf } from './meta';
+import { treemap } from './tree';
+import create from './create';
+
+class Id {
+  static symbol = Symbol('@id');
+  static data = At(Id.symbol);
+  static ref = compose(Id.data, At('ref'));
+  static value = compose(Id.data, At('value'));
+  static Type = compose(Id.data, At('Type'));
+
+  constructor(Type, path, value, ref) {
+    this.Type = Type;
+    this.path = path;
+    this.value = value;
+    this.ref = ref;
+  }
+}
+
+export default function Identity(microstate, fn) {
+
+  let paths = identify(microstate, {});
+
+  return { get, transition };
+
+  function get() {
+    return view(Id.ref, paths);
+  }
+
+  function transition(Type, name, path, args) {
+    let atom = view(Id.value, paths);
+    let Root = view(Id.Type, paths);
+    let local = link2(create(Type), Type, path, atom, Root, []);
+    let next = local[name](...args);
+    return paths = identify(next, paths);
+  }
+
+  function identify(microstate, pathmap) {
+    return treemap(node => {
+      let path = pathOf(node);
+      let id = view(compose(Path(path), Id.data), pathmap);
+      if (id != null && id.Type === typeOf(node) && id.value === valueOf(node)) {
+        return id;
+      } else {
+        return proxy(node, path);
+      }
+    }, microstate);
+
+    function proxy(microstate, path) {
+      let Type = typeOf(microstate);
+      let Proxy = MicrostateType(Type, transitionFn, propertyFn);
+      Proxy.name = `Id<${Type.name}>`;
+      AtomOf.instance(Proxy, { atomOf: () => view(Id.value, paths) });
+
+      let value = valueOf(microstate);
+
+      let ref = link2(new Proxy(value), Type, path, 'polymorphic', view(Id.Type, paths), []);
+
+      return {
+        [Id.symbol]: new Id(Type, path, value, ref)
+      };
+    }
+  }
+
+  function transitionFn(object, Type, path, name, method, ...args) {
+    return fn(Type, name, path, args);
+  }
+
+  function propertyFn(self, slot, key, path) {
+    let location = compose(Path(path), Id.ref);
+    return view(location, paths);
+  }
+}

--- a/src/meta.js
+++ b/src/meta.js
@@ -1,11 +1,17 @@
+import { type } from 'funcadelic';
+
 import { At, view, set, over, compose, Path } from './lens';
 
 export function root(microstate, Type, value) {
-  return link(microstate, new Location(Type, []), value);
+  return set(Meta.data, new Meta(new Location(Type, []), value), microstate);
 }
 
 export function link(microstate, location, atom, owner = location) {
   return set(Meta.data, new Meta(location, atom, owner), microstate);
+}
+
+export function link2(object, Type, path, atom, Owner, ownerPath) {
+  return set(Meta.data, new Meta(new Location(Type, path), atom, new Location(Owner, ownerPath)), object);
 }
 
 export function mount(microstate, substate, key) {
@@ -29,10 +35,6 @@ export function locationOf(microstate) {
   return view(Meta.location, microstate);
 }
 
-export function atomOf(microstate) {
-  return view(Meta.atom, microstate);
-}
-
 export function ownerOf(microstate) {
   return view(Meta.owner, microstate);
 }
@@ -42,7 +44,7 @@ export function typeOf(microstate) {
 }
 
 export function pathOf(microstate) {
-  return view(Meta.path, microstate);
+  return view(Meta.path, microstate) || [];
 }
 
 export class Meta {
@@ -54,9 +56,9 @@ export class Meta {
   static Type = compose(Meta.location, At("Type"));
   static path = compose(Meta.location, At("path"));
 
-  constructor(location, atom, owner) {
-    this.location = location;
+  constructor(location, atom, owner = location) {
     this.atom = atom;
+    this.location = location;
     this.owner = owner;
   }
 
@@ -80,3 +82,17 @@ class Location {
     return Path(this.path);
   }
 }
+
+export const AtomOf = type(class AtomOf {
+  atomOf(object) {
+    return this(object).atomOf(object);
+  }
+});
+
+AtomOf.instance(Object, {
+  atomOf(object) {
+    return view(Meta.atom, object);
+  }
+});
+
+export const { atomOf } = AtomOf.prototype;

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,6 @@
+import Identity from './identity';
+
+export default function Store(Type, value, observe = x => x) {
+  let { get, transition } = Identity(Type, value, (...args) => observe(transition(...args)));
+  return get();
+}

--- a/src/tree.js
+++ b/src/tree.js
@@ -1,0 +1,37 @@
+import { append, type } from 'funcadelic';
+import { metaOf } from './meta';
+
+export const Tree = type(class Tree {
+  visit(object) {
+    let visit = this(object).visit || (node => metaOf(node) != null);
+    return visit(object);
+  }
+
+  treemap(fn, object) {
+    if (visit(object)) {
+      return this(object).treemap(fn, object);
+    } else {
+      return object;
+    }
+  }
+});
+
+export const { visit, treemap } = Tree.prototype;
+
+Tree.instance(Object, {
+  treemap(fn, object) {
+    let next = fn(object);
+    let keys = Object.keys(object);
+    if (next === object || keys.length === 0) {
+      return next;
+    } else {
+      return append(next, keys.reduce((properties, key) => {
+        return append(properties, {
+          get [key]() {
+            return treemap(fn, object[key]);
+          }
+        });
+      }, {}));
+    }
+  }
+});

--- a/tests/identity.test.js
+++ b/tests/identity.test.js
@@ -1,0 +1,67 @@
+import expect from 'expect';
+
+import { create, Identity, valueOf } from '../index';
+
+
+class Str {
+  get state() {
+    return valueOf(this);
+  }
+}
+
+class Person {
+  firstName = Str;
+  lastName = Str;
+}
+
+describe('identity', function() {
+  let t;
+  let id;
+  let initial;
+  let initialFirstName;
+  let initialLastName;
+  let value = { firstName: "Charles", lastName: "Lowell" };
+  beforeEach(function() {
+    id = Identity(create(Person, value), (...args) => t = args);
+    initial = id.get();
+    initialFirstName = initial.firstName;
+    initialLastName = initial.lastName;
+  });
+
+  it('is an instance of Person', () => {
+    expect(initial).toBeInstanceOf(Person);
+    expect(initial.firstName).toBeInstanceOf(Str);
+  });
+
+  it('has the right properties', function() {
+    expect(valueOf(initial)).toBe(value);
+    expect(initial.firstName.state).toEqual('Charles');
+    expect(initial.lastName.state).toEqual('Lowell');
+  });
+
+  describe('invoking a transition', function() {
+    beforeEach(()=> {
+      id.get().firstName.set('Carlos');
+    });
+    it('invokes the transition callback to capture the location of the the transition', ()=> {
+      expect(t).toEqual([Str, 'set', ['firstName'], ['Carlos']]);
+    });
+    it('does not actually perform the transition yet', ()=> {
+      expect(id.get()).toBe(initial);
+    });
+
+    describe('calling the id.transition function with the supplied arguments ', ()=> {
+      beforeEach(()=> {
+        id.transition(...t);
+      });
+      it('updates the root reference to a new instance of the same type', ()=> {
+        expect(initial).toBeInstanceOf(Person);
+        expect(id.get()).not.toBe(initial);
+      });
+      it('changes the child node that changed, but not the child node that did not', () => {
+        expect(id.get().firstName).not.toBe(initialFirstName);
+        expect(id.get().lastName).not.toBe(initialLastName);
+      });
+    });
+  });
+});


### PR DESCRIPTION
A major question lingering over the atomic microstates refactor is how
it would work with identity (the mechanism for maintaing a stable
graph of references).

This change contains an implementation of identity using the atomic
microstates architecture.

The following new constructs were required:

### Polymorphic `atomOf()`

With an atomic microstate architecture, microstates no longer hold a
reference directly to their values. Instead, they hold a reference
directly to their paths, and in order to retrieve their values, they
look up that their path inside of an atom.

This poses a problem for stable identities because the atom needs to
change, but the JavaScript reference must remain the same. To solve
this, we make `atomOf()` a polymorhpic function of the `AtomOf`
typeclass.

The default implementation of `atomOf` returns the atom to which the
current microstate holds a reference. The `Id<Type>` implementation
however, returns the top level value of the identity which changes
over time with each transition.

### Extended MicrostateType()

There is a lot that is the same between the base microstate type
instantiated with `create`, and the the Identity microstate
type. Things like maintaining the meta information, the `set`
transition, caching instance properties, etc...

However, there are some important places where we want to diverge,
specifically in how transitions are handled, and properties are
resolved.

This introduces new parameters to the `transitionFn` and `propertyFn`,
specifically, the `Type`, and `path` parameters where the transition
is happening or the property is being resolved are both now passed.
is called, or a property is resolved. This allows us to have a single.

### Tree

In order to reason about the entire tree as a whole, we introduce a
lightweight `Tree` class not dissimilar to the `Profuctor` class in
the current implementation.

It is expected that this will only be needed for the identity map, and
not for implementing the rest of the architecture.

### Higher Order Store

Identity was previously interwined with the concept of `Store`. This
meant that integrating with other stores like Redux and Obvservable,
required a little bit of massaging or integrating with the observation
mechanism.

The Identity() function implemented here takes a microstate and a
transition event callback, returns two things: a function `get` which returns the
current reference to the root id microstate, and a `transition`
function which actually causes a transition to happen.

So, when a caller invokes a transition from the microstate graph, it
invokes the callback with the `Type`, `path`, `name`, `args` of where
the transition happened. This is the same signature as the transition
callback, and so the idea is that at some point, you invoke it with
those arguments.

So why would you want to split a transition into two phases? The
answer is that by makeing it

So for example, a fully synchronous Store would immediately delegate
from the callback to the transition function:

```js
let { get, transition } = Identity(create(Number, 0), (...args) => transition(...args));
id.get().increment();
id.get() //> Id<Number> { 1 }
```

Redux, which is also a synchronous store can be implementing in a
straightforward fashion

```js
let { get, transition } = Identity(Create(Number, 0), (Type, path, name, args) => {
  store.dispatch({
    isMicrostateTransition: true
    type: `${Type.name}.#{name}${path.join('/')}`,
    Type,
    path,
    name,
    args
  })
  return get()
})

// and in reducer:
function microstateRducer(state, action) {
  if (action.isMicrostateTransition) {
    let { Type, path, name, args } = action;
    transition(Type, path, name, args);
    return id.get();
  }
}

```

Obviously, the current store is implemented easily too:

```js
export default function Store(Type, value, observe = x => x) {
  let { get, transition } = Identity(Type, value, (...args) => observe(transition(...args)));
  return get();
}
```

Follow on work:

- [ ] Make sure that microstate types are stable: same constructor for
  given `Type`
- [ ] make sure all function parameters make sense and are aligned
- [ ] a uniform linking function (link / link2 is a no-go)