### PR TITLE
Normalize transition and property handlers.

### DIFF
--- a/src/create.js
+++ b/src/create.js
@@ -4,30 +4,29 @@ import MicrostateType from './microstate-type';
 
 export default function create(Type, value) {
   let Microstate = MicrostateType(Type, transition, property);
-  // return root(Type, value, () => new Microstate(value))
   return new Microstate(value);
 }
 
-function transition(microstate, Type, path, name, method, ...args) {
-  let owner = ownerOf(microstate);
-  let context = link(microstate, locationOf(microstate), atomOf(microstate));
+function transition(object, Type, path, name, method, ...args) {
+  let owner = ownerOf(object);
+  let context = link(object, locationOf(object), atomOf(object));
   let result = method.apply(context, args);
 
   function patch() {
     if (metaOf(result)) {
       return atomOf(result);
     } else {
-      let { lens } = locationOf(microstate);
-      return set(lens, result, atomOf(microstate));
+      let { lens } = locationOf(object);
+      return set(lens, result, atomOf(object));
     }
   }
 
   return link(create(owner.Type), owner, patch());
 }
 
-export function property(microstate, slot, key) {
-  let value = valueOf(microstate);
-  let expanded = typeof slot === 'function' ? create(slot, value) : slot;
-  let substate = value != null && value[key] != null ? expanded.set(value[key]) : expanded;
-  return mount(microstate, substate, key);
+function property(object, Type, path, name, currentValue) {
+  let value = valueOf(object);
+  let expanded = typeof currentValue === 'function' ? create(currentValue, value) : currentValue;
+  let substate = value != null && value[name] != null ? expanded.set(value[name]) : expanded;
+  return mount(object, substate, name);
 }

--- a/src/identity.js
+++ b/src/identity.js
@@ -68,7 +68,7 @@ export default function Identity(microstate, fn) {
     return fn(Type, name, path, args);
   }
 
-  function propertyFn(self, slot, key, path) {
+  function propertyFn(object, Type, path, /* name, currentValue */) {
     let location = compose(Path(path), Id.ref);
     return view(location, paths);
   }

--- a/src/microstate-type.js
+++ b/src/microstate-type.js
@@ -12,7 +12,7 @@ export default function MicrostateType(Type, transitionFn, propertyFn) {
     constructor(value) {
       super(value);
       Object.defineProperties(this, map((slot, key) => {
-        return CachedProperty(key, self => propertyFn(self, slot, key, pathOf(this).concat(key)));
+        return CachedProperty(key, self => propertyFn(self, Type, pathOf(this).concat(key), key, slot));
       }, this));
       return root(this, Type, value);
     }


### PR DESCRIPTION
It feels like emerging with most abstract operations on a microstate are the trio of `object`, `Type`, `path`, and `name` so we make those the first four arguments of both the property interface and the transition interface.