### PR TITLE
valueOf() should work with any object.

### DIFF
--- a/src/meta.js
+++ b/src/meta.js
@@ -15,9 +15,9 @@ export function mount(microstate, substate, key) {
 }
 
 export function valueOf(object) {
-  let { lens } = view(Meta.location, object);
-  if (lens != null) {
-    return view(lens, atomOf(object));
+  let location = view(Meta.location, object);
+  if (location != null) {
+    return view(location.lens, atomOf(object));
   } else {
     return object;
   }

--- a/tests/lab.test.js
+++ b/tests/lab.test.js
@@ -23,6 +23,17 @@ describe('Lab', () => {
       return !!value;
     }
   }
+
+  describe('valueOf() a POJO', ()=> {
+    it('is the same as the POJO', ()=> {
+      let pojo = {};
+      expect(valueOf(pojo)).toBe(pojo);
+      expect(valueOf(null)).toBe(null);
+      expect(valueOf(undefined)).toBe(undefined);
+    });
+  });
+
+
   describe('a simple, global microstate', () => {
     let ms;
 


### PR DESCRIPTION
A pillar of microstates is that you can ask the `valueOf` anything at any time and it should return to you a simple POJO which can be used to reconstruct the value.

For microstates this is the underlying value, for everything other thing, it's the thing.

This was blowing up before because non-microstates don't have `Meta` information.