### PR TITLE
Ignore examples and query in coverage report.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
   },
   "nyc": {
     "exclude": [
-      "**/tests"
+      "**/tests",
+      "examples",
+      "src/query.js"
     ]
   }
 }


### PR DESCRIPTION
We definitely want to have a solid coverage of the core library being developed under lab, however, the examples directory is not included in that core library. Also, the query library was copied over wholesale from microstates as a convenience.

This removes examples and query.js from the coverage report.